### PR TITLE
ci: align main workflow files with dev ahead of release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   packages: write
   contents: read
+  pull-requests: read
 
 jobs:
   publish:


### PR DESCRIPTION
Automated pre-release alignment. Overwrites the files that would otherwise conflict in the dev -> main release merge with their current `dev` blobs (dev is canonical; main is expendable for the release). Only conflict-intersection files are touched - no version bump or application code is promoted here; the dev -> main release PR remains the path that carries the actual payload.